### PR TITLE
Move CpuUtilReporter instance creation out of report()

### DIFF
--- a/test/cpu_util_reporter_test.py
+++ b/test/cpu_util_reporter_test.py
@@ -52,10 +52,10 @@ class TestCpuUtilReporter(unittest.TestCase):
         cpu_util = Mock()
         cpu_util.get_totalcpu_util = Mock(return_value = self.cpu_usage_total)
         printer = Mock()
-        report = CpuUtilReporter(cpu_util, cpu_filter, printer, options)
+        report = CpuUtilReporter(cpu_filter, printer, options)
         timestamp = '2016-7-18 IST'
 
-        report.print_report(timestamp)
+        report.print_report(cpu_util, timestamp)
 
         printer.assert_called_with('2016-7-18 IST\tALL\t 1.23\t  2.34\t 3.45\t    4.56\t 5.67\t  6.78\t   7.89\t    8.9\t  1.34\t  2.45')
 
@@ -67,9 +67,9 @@ class TestCpuUtilReporter(unittest.TestCase):
         printer = Mock()
         cpu_util = Mock()
         timestamp = '2016-7-18 IST'
-        report = CpuUtilReporter(cpu_util, cpu_filter, printer, options)
+        report = CpuUtilReporter(cpu_filter, printer, options)
 
-        report.print_report(timestamp)
+        report.print_report(cpu_util, timestamp)
 
         calls = [call(' Timestamp\tCPU\t %usr\t %nice\t %sys\t %iowait\t %irq\t %soft\t %steal\t %guest\t %nice\t %idle'),
                  call('2016-7-18 IST\t  1\t 1.43\t  2.35\t 2.45\t    3.76\t 6.45\t  2.58\t   2.59\t    5.6\t  2.34\t  6.67'),
@@ -86,9 +86,9 @@ class TestCpuUtilReporter(unittest.TestCase):
         cpu_util = Mock()
         cpu_util.get_totalcpu_util = Mock(return_value = self.cpu_usage_total)
         timestamp = '2016-7-18 IST'
-        report = CpuUtilReporter(cpu_util, cpu_filter, printer, options)
+        report = CpuUtilReporter(cpu_filter, printer, options)
 
-        report.print_report(timestamp)
+        report.print_report(cpu_util, timestamp)
 
         calls = [call(' Timestamp\tCPU\t %usr\t %nice\t %sys\t %iowait\t %irq\t %soft\t %steal\t %guest\t %nice\t %idle'),
                  call('2016-7-18 IST\tALL\t 1.23\t  2.34\t 3.45\t    4.56\t 5.67\t  6.78\t   7.89\t    8.9\t  1.34\t  2.45'),


### PR DESCRIPTION
Allows for CpuUtilReporter to have state outside of the report cycles
